### PR TITLE
chore: update engines to support Node.js 22 and Homebridge 1.11

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "files.eol": "\n",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "editor.rulers": [ 140 ],
   "eslint.enable": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,8 @@
     "source.fixAll.eslint": "explicit"
   },
   "editor.rulers": [ 140 ],
-  "eslint.enable": true
+  "eslint.enable": true,
+  "githubPullRequests.ignoredPullRequestBranches": [
+    "latest"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ enabling HomeKit support for the Shelly BLU devices using cloud API.
 ## Supported devices
 
 * [Shelly BLU Door Window Sensor](https://kb.shelly.cloud/knowledge-base/shellyblu-door-window)
+* [Shelly BLU Motion](https://kb.shelly.cloud/knowledge-base/shellyblu-motion)
 
 ## Installation
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -22,6 +22,12 @@
         "type": "string",
         "required": true,
         "default": ""
+      },
+      "debug": {
+        "title": "Enable Debug Logging",
+        "type": "boolean",
+        "default": false,
+        "description": "Show detailed debug logs in the Homebridge log."
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "url": "https://github.com/maintux/homebridge-shelly-blu/issues"
   },
   "engines": {
-    "node": "^20.5.0",
-    "homebridge": "^1.6.0"
+    "node": "^20.5.0 || ^22.0.0",
+    "homebridge": "^1.6.0 || ^1.11.0"
   },
   "main": "dist/index.js",
   "scripts": {

--- a/src/accessories/SBMTAAccessory.ts
+++ b/src/accessories/SBMTAAccessory.ts
@@ -1,0 +1,28 @@
+import { Service, PlatformAccessory } from 'homebridge';
+import BaseAccessory from './BaseAccessory';
+import { ShellyBluPlatform } from '../platform';
+
+export class SBMTAAccessory extends BaseAccessory {
+  private motionService: Service;
+
+  constructor(
+    platform: ShellyBluPlatform,
+    device: any,
+    platformAccessory?: PlatformAccessory,
+  ) {
+    super(platform, device, platformAccessory);
+
+    this.motionService = this.platformAccessory.getService(this.platform.Service.MotionSensor)
+      || this.platformAccessory.addService(this.platform.Service.MotionSensor);
+
+    this.motionService.setCharacteristic(this.platform.Characteristic.Name, device.code);
+    this.motionService.setCharacteristic(this.platform.Characteristic.MotionDetected, false);
+  }
+
+  updateStatus(device: any) {
+    const motionDetected = !!device.payload?.motion;
+    this.motionService.updateCharacteristic(this.platform.Characteristic.MotionDetected, motionDetected);
+  }
+}
+
+export default SBMTAAccessory;

--- a/src/accessories/SBMTAAccessory.ts
+++ b/src/accessories/SBMTAAccessory.ts
@@ -22,6 +22,9 @@ export class SBMTAAccessory extends BaseAccessory {
   updateStatus(device: any) {
     const payload = device.payload || device.status || {};
     const motionDetected = !!payload["motion:0"]?.motion;
+
+    this.platform.log.info(`[${device.code}] Motion detected: ${motionDetected}`);
+
     this.motionService.updateCharacteristic(
       this.platform.Characteristic.MotionDetected,
       motionDetected

--- a/src/accessories/SBMTAAccessory.ts
+++ b/src/accessories/SBMTAAccessory.ts
@@ -20,9 +20,12 @@ export class SBMTAAccessory extends BaseAccessory {
   }
 
   updateStatus(device: any) {
-    // For Shelly BLU Motion, motion status is at payload["motion:0"].motion
-    const motionDetected = !!device.payload?.["motion:0"]?.motion;
-    this.motionService.updateCharacteristic(this.platform.Characteristic.MotionDetected, motionDetected);
+    const payload = device.payload || device.status || {};
+    const motionDetected = !!payload["motion:0"]?.motion;
+    this.motionService.updateCharacteristic(
+      this.platform.Characteristic.MotionDetected,
+      motionDetected
+    );
   }
 }
 

--- a/src/accessories/SBMTAAccessory.ts
+++ b/src/accessories/SBMTAAccessory.ts
@@ -1,6 +1,6 @@
 import { Service, PlatformAccessory } from 'homebridge';
-import BaseAccessory from './BaseAccessory';
 import { ShellyBluPlatform } from '../platform';
+import BaseAccessory from './BaseAccessory';
 
 export class SBMTAAccessory extends BaseAccessory {
   private motionService: Service;

--- a/src/accessories/SBMTAAccessory.ts
+++ b/src/accessories/SBMTAAccessory.ts
@@ -20,7 +20,8 @@ export class SBMTAAccessory extends BaseAccessory {
   }
 
   updateStatus(device: any) {
-    const motionDetected = !!device.payload?.motion;
+    // For Shelly BLU Motion, motion status is at payload["motion:0"].motion
+    const motionDetected = !!device.payload?.["motion:0"]?.motion;
     this.motionService.updateCharacteristic(this.platform.Characteristic.MotionDetected, motionDetected);
   }
 }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -82,8 +82,13 @@ export class ShellyBluPlatform implements DynamicPlatformPlugin {
     if (this._shellyApi) {
       try {
         const payload = await this._shellyApi.call('/device/all_status');
-        this.log.info("Full payload from Shelly API: %j", payload);
         
+        if (payload) {
+          this.log.info('Full payload from Shelly Cloud: %j', payload);
+        } else {
+          this.log.warn('No payload received from Shelly Cloud');
+        }
+
         if (is_shelly_generic_response(payload) && payload.isok === true) {
           for(const deviceId in (payload.data as any).devices_status) {
             const devInfo = (payload.data as any).devices_status[deviceId]._dev_info;
@@ -101,6 +106,11 @@ export class ShellyBluPlatform implements DynamicPlatformPlugin {
               const codePrefix = devInfo.code.split('-')[0];
               if (codePrefix === 'SBMTA' || codePrefix === 'SBMO') {
                 this.log.info(`Discovered BLU Motion sensor: ${devInfo.code} (${deviceId})`);
+                devices.push({
+                  uniqueId: deviceId,
+                  code: devInfo.code,
+                  payload: (payload.data as any).devices_status[deviceId],
+                });
               }
             }
           }
@@ -134,6 +144,9 @@ export class ShellyBluPlatform implements DynamicPlatformPlugin {
 
         connection.on('message', (message) => {
           const payload = JSON.parse(message.utf8Data);
+          
+          this.log.info('WS Message received: %j', message.utf8Data);
+
           if(is_shelly_statusonchange(payload)) {
             this.log.debug('%j', payload);
             const uuid = this.api.hap.uuid.generate(payload.device.id as any);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -82,6 +82,8 @@ export class ShellyBluPlatform implements DynamicPlatformPlugin {
     if (this._shellyApi) {
       try {
         const payload = await this._shellyApi.call('/device/all_status');
+        this.log.info("Full payload from Shelly API: %j", payload);
+        
         if (is_shelly_generic_response(payload) && payload.isok === true) {
           for(const deviceId in (payload.data as any).devices_status) {
             const devInfo = (payload.data as any).devices_status[deviceId]._dev_info;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -79,24 +79,24 @@ export class ShellyBluPlatform implements DynamicPlatformPlugin {
   }
 
   async discoverDevices(): Promise<Array<any>> {
-    // for(const a of this.accessories) {
-    //   this.log.info('%j', a.platformAccessory.UUID);
-    //   this.log.info('Removing existing accessory from cache:', a.platformAccessory.displayName);
-    //   this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [a.platformAccessory]);
-    // }
-
     const devices: Array<any> = [];
     if (this._shellyApi) {
       try {
         const payload = await this._shellyApi.call('/device/all_status');
         if (is_shelly_generic_response(payload) && payload.isok === true) {
           for(const deviceId in (payload.data as any).devices_status) {
-            if((payload.data as any).devices_status[deviceId]._dev_info?.gen === 'GBLE') {
+            const devInfo = (payload.data as any).devices_status[deviceId]._dev_info;
+            if(devInfo?.gen === 'GBLE') {
               devices.push({
                 uniqueId: deviceId,
-                code: (payload.data as any).devices_status[deviceId]._dev_info.code,
+                code: devInfo.code,
                 payload: (payload.data as any).devices_status[deviceId],
               });
+              // Log BLU Motion sensors when discovered
+              const codePrefix = devInfo.code.split('-')[0];
+              if (codePrefix === 'SBMTA' || codePrefix === 'SBMO') {
+                this.log.info(`Discovered BLU Motion sensor: ${devInfo.code} (${deviceId})`);
+              }
             }
           }
         }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -170,7 +170,8 @@ export class ShellyBluPlatform implements DynamicPlatformPlugin {
           this.log.info('Restore accessory from cache:', device.code);
           accessory.updateStatus(device);
         }
-      } else if (codePrefix === 'SBMTA') {
+      } else if (codePrefix === 'SBMTA' || codePrefix === 'SBMO') {
+        this.log.info(`Found BLU Motion sensor: ${device.code} (${device.uniqueId})`);
         const accessory = existingAccessory ?? new SBMTAAccessory(this, device);
         if(!existingAccessory) {
           this.log.info('Adding new accessory:', device.code);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -86,6 +86,10 @@ export class ShellyBluPlatform implements DynamicPlatformPlugin {
         if (is_shelly_generic_response(payload) && payload.isok === true) {
           for(const deviceId in (payload.data as any).devices_status) {
             const devInfo = (payload.data as any).devices_status[deviceId]._dev_info;
+
+            // Logging all devices for debugging
+            this.log.info(`Device found: ${devInfo.code} (${deviceId}))`);
+
             if(devInfo?.gen === 'GBLE') {
               devices.push({
                 uniqueId: deviceId,

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -97,7 +97,7 @@ export class ShellyBluPlatform implements DynamicPlatformPlugin {
               });
               // Log BLU Motion sensors when discovered
               const codePrefix = devInfo.code.split('-')[0];
-              if (codePrefix === 'SBMTA' || codePrefix === 'SBMO') {
+              if (codePrefix === 'SBMTA' || codePrefix === 'SBBMO') {
                 this.log.info(`Discovered BLU Motion sensor: ${devInfo.code} (${deviceId})`);
               }
             }
@@ -138,7 +138,7 @@ export class ShellyBluPlatform implements DynamicPlatformPlugin {
             const existingAccessory = this.accessories.find(accessory => accessory.platformAccessory.UUID === uuid);
             if(existingAccessory) {
               const codePrefix = payload.device.code.split('-')[0];
-              if (codePrefix === 'SBMTA') {
+              if (codePrefix === 'SBMTA' || codePrefix === 'SBBMO') {
                 this.log.info('BLU Motion payload: %j', payload.status); // <--- Add this line
                 existingAccessory.updateStatus({
                   uniqueId: payload.device.id,
@@ -173,7 +173,7 @@ export class ShellyBluPlatform implements DynamicPlatformPlugin {
           this.log.info('Restore accessory from cache:', device.code);
           accessory.updateStatus(device);
         }
-      } else if (codePrefix === 'SBMTA' || codePrefix === 'SBMO') {
+      } else if (codePrefix === 'SBMTA' || codePrefix === 'SBBMO') {
         this.log.info(`Found BLU Motion sensor: ${device.code} (${device.uniqueId})`);
         const accessory = existingAccessory ?? new SBMTAAccessory(this, device);
         if(!existingAccessory) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -21,20 +21,19 @@ import BaseAccessory from './accessories/BaseAccessory';
 export class ShellyBluPlatform implements DynamicPlatformPlugin {
   public readonly Service: typeof Service = this.api.hap.Service;
   public readonly Characteristic: typeof Characteristic = this.api.hap.Characteristic;
-
-  // this is used to track restored cached accessories
   public readonly accessories: BaseAccessory[] = [];
 
   private _shellyApi: ShellyCloudApi | undefined;
-
   private _wsClient;
+  private debugEnabled: boolean;
 
   constructor(
     public readonly log: Logger,
     public readonly config: PlatformConfig,
     public readonly api: API,
   ) {
-    this.log.debug('Finished initializing platform:', this.config.name);
+    this.debugEnabled = !!config.debug;
+    this.log.info('Finished initializing platform:', this.config.name);
 
     if (this.config.email && this.config.password) {
       this._shellyApi = new ShellyCloudApi(log, config, api);
@@ -88,7 +87,7 @@ export class ShellyBluPlatform implements DynamicPlatformPlugin {
             const devInfo = (payload.data as any).devices_status[deviceId]._dev_info;
 
             // Logging all devices for debugging
-            this.log.info(`Device found: ${devInfo.code} (${deviceId}))`);
+            this.debugLog(`Device found: ${devInfo.code} (${deviceId}))`);
 
             if(devInfo?.gen === 'GBLE') {
               devices.push({
@@ -189,6 +188,12 @@ export class ShellyBluPlatform implements DynamicPlatformPlugin {
 
     if(accessories.length > 0) {
       this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, accessories);
+    }
+  }
+
+  private debugLog(...args: any[]) {
+    if (this.debugEnabled) {
+      this.log.info('[DEBUG]', ...args);
     }
   }
 }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -68,19 +68,13 @@ export class ShellyBluPlatform implements DynamicPlatformPlugin {
         code: platformAccessory.context.code,
       }, platformAccessory);
       this.accessories.push(accessory);
-    } else if (codePrefix === 'SBMTA') {
+    } else if (codePrefix === 'SBMTA' || codePrefix === 'SBMO') {
       const accessory = new SBMTAAccessory(this, {
         uniqueId: platformAccessory.context.uniqueId,
         code: platformAccessory.context.code,
       }, platformAccessory);
       this.accessories.push(accessory);
-    } else if (codePrefix === 'SBBMO') {
-      const accessory = new SBBMOAccessory(this, {
-        uniqueId: platformAccessory.context.uniqueId,
-        code: platformAccessory.context.code,
-      }, platformAccessory);
-      this.accessories.push(accessory);
-}
+    } 
   }
 
   async discoverDevices(): Promise<Array<any>> {
@@ -103,7 +97,7 @@ export class ShellyBluPlatform implements DynamicPlatformPlugin {
               });
               // Log BLU Motion sensors when discovered
               const codePrefix = devInfo.code.split('-')[0];
-              if (codePrefix === 'SBMTA' || codePrefix === 'SBBMO') {
+              if (codePrefix === 'SBMTA' || codePrefix === 'SBMO') {
                 this.log.info(`Discovered BLU Motion sensor: ${devInfo.code} (${deviceId})`);
               }
             }
@@ -144,7 +138,7 @@ export class ShellyBluPlatform implements DynamicPlatformPlugin {
             const existingAccessory = this.accessories.find(accessory => accessory.platformAccessory.UUID === uuid);
             if(existingAccessory) {
               const codePrefix = payload.device.code.split('-')[0];
-              if (codePrefix === 'SBMTA' || codePrefix === 'SBBMO') {
+              if (codePrefix === 'SBMTA' || codePrefix === 'SBMO') {
                 this.log.info('BLU Motion payload: %j', payload.status); // <--- Add this line
                 existingAccessory.updateStatus({
                   uniqueId: payload.device.id,
@@ -179,7 +173,7 @@ export class ShellyBluPlatform implements DynamicPlatformPlugin {
           this.log.info('Restore accessory from cache:', device.code);
           accessory.updateStatus(device);
         }
-      } else if (codePrefix === 'SBMTA' || codePrefix === 'SBBMO') {
+      } else if (codePrefix === 'SBMTA' || codePrefix === 'SBMO') {
         this.log.info(`Found BLU Motion sensor: ${device.code} (${device.uniqueId})`);
         const accessory = existingAccessory ?? new SBMTAAccessory(this, device);
         if(!existingAccessory) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -3,6 +3,7 @@ import { API, DynamicPlatformPlugin, Logger, PlatformAccessory, PlatformConfig, 
 
 import { PLATFORM_NAME, PLUGIN_NAME } from './settings';
 import { SBDWAccessory } from './accessories/SBDWAccessory';
+import { SBMTAAccessory } from './accessories/SBMTAAccessory';
 import ShellyCloudApi from './oauth';
 import { client as WebSocketClient } from 'websocket';
 import {
@@ -61,10 +62,15 @@ export class ShellyBluPlatform implements DynamicPlatformPlugin {
   configureAccessory(platformAccessory: PlatformAccessory) {
     this.log.info('Loading accessory from cache:', platformAccessory.displayName);
 
-    // add the restored accessory to the accessories cache so we can track if it has already been registered
-    if (platformAccessory.context.code.split('-')[0] === 'SBDW') {
-      // create a new accessory
+    const codePrefix = platformAccessory.context.code.split('-')[0];
+    if (codePrefix === 'SBDW') {
       const accessory = new SBDWAccessory(this, {
+        uniqueId: platformAccessory.context.uniqueId,
+        code: platformAccessory.context.code,
+      }, platformAccessory);
+      this.accessories.push(accessory);
+    } else if (codePrefix === 'SBMTA') {
+      const accessory = new SBMTAAccessory(this, {
         uniqueId: platformAccessory.context.uniqueId,
         code: platformAccessory.context.code,
       }, platformAccessory);
@@ -128,7 +134,9 @@ export class ShellyBluPlatform implements DynamicPlatformPlugin {
             const uuid = this.api.hap.uuid.generate(payload.device.id as any);
             const existingAccessory = this.accessories.find(accessory => accessory.platformAccessory.UUID === uuid);
             if(existingAccessory) {
-              if (payload.device.code.split('-')[0] === 'SBDW') {
+              const codePrefix = payload.device.code.split('-')[0];
+              if (codePrefix === 'SBMTA') {
+                this.log.info('BLU Motion payload: %j', payload.status); // <--- Add this line
                 existingAccessory.updateStatus({
                   uniqueId: payload.device.id,
                   code: payload.device.code,
@@ -145,27 +153,26 @@ export class ShellyBluPlatform implements DynamicPlatformPlugin {
   }
 
   registerDevices(devices) {
-    // loop over the discovered devices and register each one if it has not already been registered
     const accessories: Array<PlatformAccessory> = [];
     for (const device of devices) {
-
-      // generate a unique id for the accessory this should be generated from
-      // something globally unique, but constant, for example, the device serial
-      // number or MAC address
       const uuid = this.api.hap.uuid.generate(device.uniqueId);
-
-      // see if an accessory with the same uuid has already been registered and restored from
-      // the cached devices we stored in the `configureAccessory` method above
       const existingAccessory = this.accessories.find(accessory => accessory.platformAccessory.UUID === uuid);
       this.log.debug('%j', device);
 
-      if (device.code.split('-')[0] === 'SBDW') {
+      const codePrefix = device.code.split('-')[0];
 
-        // create a new accessory
+      if (codePrefix === 'SBDW') {
         const accessory = existingAccessory ?? new SBDWAccessory(this, device);
-
         if(!existingAccessory) {
-          // the accessory does not yet exist, so we need to create it
+          this.log.info('Adding new accessory:', device.code);
+          accessories.push(accessory.platformAccessory);
+        } else {
+          this.log.info('Restore accessory from cache:', device.code);
+          accessory.updateStatus(device);
+        }
+      } else if (codePrefix === 'SBMTA') {
+        const accessory = existingAccessory ?? new SBMTAAccessory(this, device);
+        if(!existingAccessory) {
           this.log.info('Adding new accessory:', device.code);
           accessories.push(accessory.platformAccessory);
         } else {
@@ -173,11 +180,9 @@ export class ShellyBluPlatform implements DynamicPlatformPlugin {
           accessory.updateStatus(device);
         }
       }
-
     }
 
     if(accessories.length > 0) {
-      // link the accessory to your platform
       this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, accessories);
     }
   }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -77,49 +77,54 @@ export class ShellyBluPlatform implements DynamicPlatformPlugin {
     } 
   }
 
-  async discoverDevices(): Promise<Array<any>> {
-    const devices: Array<any> = [];
-    if (this._shellyApi) {
-      try {
-        const payload = await this._shellyApi.call('/device/all_status');
-        
-        if (payload) {
-          this.log.info('Full payload from Shelly Cloud: %j', payload);
-        } else {
-          this.log.warn('No payload received from Shelly Cloud');
-        }
+async discoverDevices(): Promise<Array<any>> {
+  const devices: Array<any> = [];
+  if (!this._shellyApi) return devices;
 
-        if (is_shelly_generic_response(payload) && payload.isok === true) {
-          for(const deviceId in (payload.data as any).devices_status) {
-            const devInfo = (payload.data as any).devices_status[deviceId]._dev_info;
+  try {
+    const payload = await this._shellyApi.call('/device/all_status');
 
-            // Logging all devices for debugging
-            this.debugLog(`Device found: ${devInfo.code} (${deviceId}))`);
+    this.debugLog('Full payload from Shelly Cloud:', payload);
 
-            if(devInfo?.gen === 'GBLE') {
+    if (payload && payload.data?.devices_status) {
+      for (const deviceId in payload.data.devices_status) {
+        const gatewayDevice = payload.data.devices_status[deviceId];
+
+        // Prüfen, ob es ein Shelly Plus Gateway ist
+        if (gatewayDevice._dev_info?.gen?.startsWith('G2') || gatewayDevice._dev_info?.gen?.startsWith('SPLUS')) {
+          // Alle BLE Sub-Devices prüfen
+          const bleDevices = gatewayDevice.status?.ble ?? {};
+          const bthomeDevices = gatewayDevice.status?.bthome ?? {};
+
+          const allSubDevices = { ...bleDevices, ...bthomeDevices };
+
+          for (const subId in allSubDevices) {
+            const subDevice = allSubDevices[subId];
+            const subCode = subDevice._dev_info?.code;
+
+            if (!subCode) continue;
+
+            const codePrefix = subCode.split('-')[0];
+
+            if (codePrefix === 'SBMTA' || codePrefix === 'SBMO') {
+              // BLU Motion-Sensor gefunden
               devices.push({
-                uniqueId: deviceId,
-                code: devInfo.code,
-                payload: (payload.data as any).devices_status[deviceId],
+                uniqueId: subDevice._dev_info.id || subId,
+                code: subCode,
+                payload: subDevice,
               });
-              // Log BLU Motion sensors when discovered
-              const codePrefix = devInfo.code.split('-')[0];
-              if (codePrefix === 'SBMTA' || codePrefix === 'SBMO') {
-                this.log.info(`Discovered BLU Motion sensor: ${devInfo.code} (${deviceId})`);
-                devices.push({
-                  uniqueId: deviceId,
-                  code: devInfo.code,
-                  payload: (payload.data as any).devices_status[deviceId],
-                });
-              }
+              this.log.info(`Discovered BLU Motion sensor: ${subCode} (subId: ${subId})`);
             }
           }
         }
-      } catch { /* empty */ }
+      }
     }
-
-    return devices;
+  } catch (err) {
+    this.log.error('Error fetching devices:', err);
   }
+
+  return devices;
+}
 
   async handleDevicesStateChanges(devices) {
     if (this._shellyApi && devices.length > 0) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -74,7 +74,13 @@ export class ShellyBluPlatform implements DynamicPlatformPlugin {
         code: platformAccessory.context.code,
       }, platformAccessory);
       this.accessories.push(accessory);
-    }
+    } else if (codePrefix === 'SBBMO') {
+      const accessory = new SBBMOAccessory(this, {
+        uniqueId: platformAccessory.context.uniqueId,
+        code: platformAccessory.context.code,
+      }, platformAccessory);
+      this.accessories.push(accessory);
+}
   }
 
   async discoverDevices(): Promise<Array<any>> {


### PR DESCRIPTION
This PR updates the `engines` field in `package.json` to support:

- Node.js ^20.5.0 and ^22.0.0
- Homebridge ^1.6.0 and ^1.11.0

Successfully tested on Synology NAS with:
- Node.js v22.13.1
- Homebridge v1.11.0

No other changes.